### PR TITLE
refactor(remove_duplicate_lines): update built-in method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed:
+- Use the built-in `View.erase()` method to simplify this plugin
+
 ## [1.0.0] - 2018-04-21
 ### Added:
 - Ability to remove duplicate lines from the entire file

--- a/remove_duplicate_lines.py
+++ b/remove_duplicate_lines.py
@@ -28,7 +28,7 @@ class RemoveDuplicateLinesCommand(sublime_plugin.TextCommand):
 
       # Delete all selections in reverse order to preserve the cursor position:
       for deletion_selection in reversed(self.view.sel()):
-        self.view.replace(edit, deletion_selection, "")
+        self.view.erase(edit, deletion_selection)
 
       self.view.sel().clear()
 


### PR DESCRIPTION
Use the built-in method called `View.erase()` in order to simplify the
logic of this plugin.

fixes #4