### PR TITLE
feat(remove_duplicate_lines): add command to the Command Palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added:
+- The command to "Remove Duplicate Lines" to the Command Palette
+
 ### Changed:
 - The built-in `View.erase()` method to simplify this plugin
 - The `README` to reflect that the first occurrence will be kept intact

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,0 +1,3 @@
+[
+  { "caption": "Remove Duplicate Lines", "command": "remove_duplicate_lines" }
+]


### PR DESCRIPTION
This commit adds a `.sublime-commands` file in order to add the
"Remove Duplicate Lines" right onto the Sublime Text Command Palette.

fixes #6

---

![screen shot 2018-05-14 at 20 57 02](https://user-images.githubusercontent.com/183227/40036825-995f8252-57be-11e8-9b82-8c00a35bee8c.png)