### PR TITLE
fix(*): ensure duplicate lines are removed without issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed:
+- Ensure that lines of different lengths are not concatenated together
+- Ensure that trailing lines are preserved
+
 ## [1.2.0] - 2018-05-15
 ### Added:
 - Installation instructions to the `README`


### PR DESCRIPTION
This commit fixes a bug where lines of different lengths were being
erroneously concatenated together. It also fixes a bug where trailing
lines are preserved. Lastly, it leverages the `OrderedDict` class to
make the operations more Pythonic, which makes it a major refactor that
changes the logic of the entire plugin.

fixes #15
fixes #14
potentially fixes #13 

---

This commit borrows heavily from #16 