### PR TITLE
feat(*): remove duplicate lines within the selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added:
+- Ability to remove all duplicate lines within one or more selection(s)
+- Ability to preserve selection after removal
+
+### Changed:
+- The `README` to reflect the new functionality including screenshots
+
+### Removed:
+- Ability to remove all lines that match the selection
+
 ## [1.2.1] - 2018-06-03
 ### Fixed:
 - Ensure that lines of different lengths are not concatenated together

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RemoveDuplicateLines - A Sublime Text Plugin
 
-A plugin for [Sublime Text](http://www.sublimetext.com/) that allows you to remove duplicate lines from the file.
+A plugin for [Sublime Text](http://www.sublimetext.com/) that allows you to remove duplicate lines from files and selections.
 
 ## Installation
 
@@ -8,10 +8,12 @@ A plugin for [Sublime Text](http://www.sublimetext.com/) that allows you to remo
   1. [Install Package Control](https://packagecontrol.io/installation)
   1. [Bring up the Command Palette](https://sublime-text.readthedocs.io/en/stable/reference/command_palette.html#how-to-use-the-command-palette) and type "Package Control: Install Package"
   1. Type "RemoveDuplicateLines" and press <kbd>enter</kbd>
+
 * **Directly**
   1. Locate the `Packages` folder in the [data directory](http://docs.sublimetext.info/en/sublime-text-3/basic_concepts.html#the-data-directory)
   1. Download the [latest version of RemoveDuplicateLines](https://github.com/ilyakam/RemoveDuplicateLines/releases/latest)
   1. Extract the archive into the `Packages` folder
+
 * **Development**
   1. [Follow the instructions on the `CONTRIBUTING` guide](./CONTRIBUTING.md#getting-started)
 
@@ -26,16 +28,16 @@ There are two ways to use this plugin:
 This removes all duplicate lines, leaving the first occurrence of each line to be unique to the entire file.
 
 | Before | After |
-| ------ | ----- |
-| ![without_before](https://user-images.githubusercontent.com/183227/39089760-422a4866-4583-11e8-94e8-545983074fd4.png) | ![without_after](https://user-images.githubusercontent.com/183227/39089761-43da04f8-4583-11e8-9901-4a85e117d952.png) |
+| :----- | :---- |
+| ![without_selection_before](https://user-images.githubusercontent.com/183227/40892300-1451b4b8-674a-11e8-95e9-041738f3ecd1.png) | ![without_selection_after](https://user-images.githubusercontent.com/183227/40892301-146c9940-674a-11e8-99a8-1878699f5114.png) |
 
 ### With a selection
 
-This removes all other duplicate selections from the file that match the initial selection.
+This removes all duplicate lines within one or more selection(s).
 
 | Before | After |
-| ------ | ----- |
-| ![with_before](https://user-images.githubusercontent.com/183227/39089762-483acb22-4583-11e8-8ac5-aa6bcb3bb01e.png) | ![with_after](https://user-images.githubusercontent.com/183227/39089763-4a46dbcc-4583-11e8-9c65-c48674dcf77c.png)
+| :----- | :---- |
+| ![with_selection_before](https://user-images.githubusercontent.com/183227/40892302-1488c674-674a-11e8-9dce-92fff33cb903.png) | ![with_selection_after](https://user-images.githubusercontent.com/183227/40892303-14b18f64-674a-11e8-9d81-cf865d06565b.png)
 
 ## Changelog
 


### PR DESCRIPTION
Overhaul the `dedup_selection()` logic so that only the duplicate lines
that appear within the selection are removed and the rest are ignored.

Do nothing if the selection does not span across more than one line.

When there are one or more cursors with nothing selected in them, remove
duplicates from the entire file (unchanged from v1.2.1).

BREAKING CHANGE: duplicate lines in a multiline selection are removed