### PR TITLE
feat(menu): add menu option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Added:
+- Menu option to activate the plugin in Edit below Sort / Permute Lines
+
 ## [2.0.0] - 2018-06-03
 ### Added:
 - Ability to remove all duplicate lines within one or more selection(s)

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,13 @@
+[
+  {
+    "id": "edit",
+    "children": [
+      {
+        "caption": "Remove Duplicate Lines",
+        "command": "remove_duplicate_lines",
+        "id": "sort_lines",
+        "mnemonic": "R"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Allow the users to remove duplicate lines without having to remember
the `shift+F5` shortcut by adding it to the Sublime Text 3 Menu. Add
the "Remove Duplicate Lines" options in the Edit menu, below the
options to sort or premute lines.

fixes #21

---

### Screenshots

#### macOS

<img width="467" alt="demo" src="https://user-images.githubusercontent.com/183227/100297710-216ceb80-2f44-11eb-9812-3e6f4ed6fb8f.png">

#### Linux

![Linux-Mint](https://user-images.githubusercontent.com/183227/100488692-92d3a800-30c4-11eb-8f37-4a2b713b04c1.png)
