### PR TITLE
docs(README): fix broken link for the "data directory"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A plugin for [Sublime Text](http://www.sublimetext.com/) that allows you to remo
   1. Type "RemoveDuplicateLines" and press <kbd>enter</kbd>
 
 * **Directly**
-  1. Locate the `Packages` folder in the [data directory](http://docs.sublimetext.info/en/sublime-text-3/basic_concepts.html#the-data-directory)
+  1. Locate the `Packages` folder in the [data directory](https://docs.sublimetext.io/guide/getting-started/basic-concepts.html#the-data-directory)
   1. Download the [latest version of RemoveDuplicateLines](https://github.com/ilyakam/RemoveDuplicateLines/releases/latest)
   1. Extract the archive into the `Packages` folder
 


### PR DESCRIPTION
The old link to the "data directory" under Installation » Directly » i.
was no longer available on the internet. After searching online for a
similar page, I found the same information at a different, seemingly
official destination. As a result of this commit, the link is now valid.

fixes #25