### PR TITLE
Option to ignore whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ This plugin can be used in two different ways:
     | :----- | :---- |
     | ![with_selection_before](https://user-images.githubusercontent.com/183227/40892302-1488c674-674a-11e8-9dce-92fff33cb903.png) | ![with_selection_after](https://user-images.githubusercontent.com/183227/40892303-14b18f64-674a-11e8-9d81-cf865d06565b.png)
 
+There is one optional setting to configure, `ignore_regex`, which is a list of regular expressions. Any line matching any regular expression in this list will be left in-place, even if it is a duplicate line.
+
+For example, to preserve whitespace when removing duplicates, set `ignore_regex` to `["^\\W*$"]` 
+
 ## Changelog
 
 See [CHANGELOG.md](./CHANGELOG.md)

--- a/RemoveDuplicateLines.sublime-settings
+++ b/RemoveDuplicateLines.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "ignore_regex": []
+}

--- a/remove_duplicate_lines.py
+++ b/remove_duplicate_lines.py
@@ -1,12 +1,9 @@
 import sublime
 import sublime_plugin
-from collections import OrderedDict
 import re
 
 
 class RemoveDuplicateLinesCommand(sublime_plugin.TextCommand):
-    ignore = [r'^\W*$']
-
     def dedupe(self, selection, edit):
         """
         Removes duplicate lines from the selected region by splitting it into lines,
@@ -14,12 +11,15 @@ class RemoveDuplicateLinesCommand(sublime_plugin.TextCommand):
         and combines everything back into a string with newlines
         """
 
+        settings = sublime.load_settings("RemoveDuplicateLines.sublime-settings")
+        ignorelist = settings.get("ignore_regex", [])
+
         selection = self.view.expand_by_class(selection, sublime.CLASS_LINE_END)
 
         seen = set()
         lines = []
         for line in self.view.substr(selection).splitlines():
-            if any(re.match(pattern, line) for pattern in self.ignore):
+            if any(re.match(pattern, line) for pattern in ignorelist):
                 lines.append(line)
             else:
                 if line not in seen:

--- a/remove_duplicate_lines.py
+++ b/remove_duplicate_lines.py
@@ -2,37 +2,39 @@ import sublime
 import sublime_plugin
 from collections import OrderedDict
 
+
 class RemoveDuplicateLinesCommand(sublime_plugin.TextCommand):
-  def dedupe(self, selection, edit):
-    """
-    Removes duplicate lines from the selected region by splitting it into lines,
-    adding them into an `OrderedDict` which automatically removes duplicates,
-    and combines everything back into a string with newlines
-    """
+    def dedupe(self, selection, edit):
+        """
+        Removes duplicate lines from the selected region by splitting it into lines,
+        adding them into an `OrderedDict` which automatically removes duplicates,
+        and combines everything back into a string with newlines
+        """
 
-    selection = self.view.expand_by_class(selection, sublime.CLASS_LINE_END)
+        selection = self.view.expand_by_class(selection, sublime.CLASS_LINE_END)
+  
+        lines = self.view.substr(selection).splitlines()
+  
+        text = '\n'.join(OrderedDict.fromkeys(lines))
+  
+        self.view.replace(edit, selection, text)
+  
+    def run(self, edit):
+        """
+        Removes duplicate lines so that each line contains a unique string
+        If one or more multiline regions are selected, it removes the duplicate
+        lines that are confined within each of the regions
+        """
 
-    lines = self.view.substr(selection).splitlines()
+        non_empty_selections = [
+            selection for selection in self.view.sel()
+            if not selection.empty()
+        ]
 
-    text = '\n'.join(OrderedDict.fromkeys(lines))
+        if non_empty_selections:
+            for selection in reversed(non_empty_selections):
+                self.dedupe(selection, edit)
 
-    self.view.replace(edit, selection, text)
-
-  def run(self, edit):
-    """
-    Removes duplicate lines so that each line contains a unique string
-    If one or more multiline regions are selected, it removes the duplicate
-    lines that are confined within each of the regions
-    """
-
-    non_empty_selections = [selection for selection in self.view.sel()
-                            if not selection.empty()]
-
-    if non_empty_selections:
-      [self.dedupe(selection, edit)
-       for selection in reversed(non_empty_selections)]
-
-    else:
-      entire_file = sublime.Region(0, self.view.size())
-
-      self.dedupe(entire_file, edit)
+        else:
+            entire_file = sublime.Region(0, self.view.size())
+            self.dedupe(entire_file, edit)


### PR DESCRIPTION
Whitespace is left in place. Only lines with content are deduplicated.

The ignore list could potentially be extended to be configurable.